### PR TITLE
fix(useScrollToTop): not working, simplify useScrollToTop hook and usage

### DIFF
--- a/src/features/library/LibraryPage/LibraryPage.module.css
+++ b/src/features/library/LibraryPage/LibraryPage.module.css
@@ -16,6 +16,8 @@
   grid-template-rows: auto 1fr auto;
   height: 100vh;
   min-height: 100dvh;
+  /* I need this for the useScrollToTop hook works. idk why */
+  overflow-y: auto;
 }
 
 .main {

--- a/src/features/library/LibraryPage/LibraryPage.tsx
+++ b/src/features/library/LibraryPage/LibraryPage.tsx
@@ -34,7 +34,7 @@ export const LibraryPage = () => {
   });
 
   const pageRef = useRef<HTMLDivElement>(null);
-  useScrollToTop(pageRef, { trigger: currentPage, isLoading: loading });
+  useScrollToTop(pageRef, [currentPage]);
 
   // Handlers updated to reset page
   const handleSearchChange = (query: string) => {

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,45 +1,11 @@
 import { type RefObject, useEffect } from "react";
 
-interface ScrollOptions<T> {
-  trigger: T;
-  isLoading: boolean;
-  behavior?: ScrollBehavior;
-  delay?: number;
-}
-
-export function useScrollToTop<E extends HTMLElement, T>(
-  ref: RefObject<E | null>,
-  { trigger, isLoading, behavior = "smooth", delay = 50 }: ScrollOptions<T>,
-): void {
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <I dont know>
+export function useScrollToTop(ref: RefObject<HTMLElement | null>, deps: readonly unknown[]) {
   useEffect(() => {
-    // Only scroll when loading is finished
-    if (isLoading) {
-      return;
-    }
-
     const el = ref.current;
-    if (!el) {
-      return;
+    if (el) {
+      el.scrollTo({ top: 0, behavior: "smooth" });
     }
-
-    let timeoutId: ReturnType<typeof setTimeout>;
-
-    // Wait for the next paint cycle
-    const rafId = requestAnimationFrame(() => {
-      // Small delay allows the browser to finish layout and
-      // ensures the smooth-scroll engine can initialize properly.
-      timeoutId = setTimeout(() => {
-        el.scrollTo({
-          top: 0,
-          behavior,
-        });
-      }, delay);
-    });
-
-    return () => {
-      cancelAnimationFrame(rafId);
-      clearTimeout(timeoutId);
-    };
-  }, [trigger, isLoading, ref, behavior, delay]);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: < it's fine >
+  }, deps);
 }

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,6 +1,6 @@
 import { type RefObject, useEffect } from "react";
 
-export function useScrollToTop(ref: RefObject<HTMLElement | null>, deps: readonly unknown[]) {
+export function useScrollToTop(ref: RefObject<HTMLElement | null>, deps: readonly unknown[]): void {
   useEffect(() => {
     const el = ref.current;
     if (el) {

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -6,6 +6,5 @@ export function useScrollToTop(ref: RefObject<HTMLElement | null>, deps: readonl
     if (el) {
       el.scrollTo({ top: 0, behavior: "smooth" });
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: < it's fine >
-  }, deps);
+  }, [ref, ...deps]);
 }


### PR DESCRIPTION
This pull request simplifies the `useScrollToTop` hook and its usage in the `LibraryPage` component. The main changes include refactoring the hook to accept a dependencies array instead of an options object, removing unnecessary logic, and updating the component and CSS to support the new behavior.

**Refactoring and simplification of scroll behavior:**

* Refactored the `useScrollToTop` hook in `useScrollToTop.ts` to accept a dependencies array (`deps`) instead of an options object, removing parameters such as `trigger`, `isLoading`, `behavior`, and `delay`, and simplifying the scroll logic to always scroll to the top smoothly when dependencies change.
* Updated the usage of `useScrollToTop` in `LibraryPage.tsx` to pass `[currentPage]` as the dependencies array, aligning with the new hook signature and simplifying the scroll trigger logic.

**CSS update to support scrolling:**

* Added `overflow-y: auto;` to the root container in `LibraryPage.module.css` to ensure the scroll-to-top behavior works as intended with the updated hook.